### PR TITLE
Fix: Correctly disable all UI controls during compression

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -502,15 +502,37 @@ void MainWindow::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus
 
 void MainWindow::setControlsEnabled(bool enabled)
 {
-    // Enable/disable all child widgets of the central widget except for the log and status label
-    foreach (QObject *obj, centralWidget()->children()) {
-        QWidget *widget = qobject_cast<QWidget*>(obj);
-        if (widget && widget != logTextEdit && widget != statusLabel && widget != progressBar) {
-            widget->setEnabled(enabled);
+    // Recursively find all child widgets and disable them, with specific exceptions.
+    QList<QWidget*> widgets = this->findChildren<QWidget *>();
+    foreach(QWidget *widget, widgets) {
+        // A list of widgets to NEVER disable.
+        if (widget == logTextEdit ||
+            widget == statusLabel ||
+            widget == progressBar ||
+            widget == logTextEdit->verticalScrollBar() ||
+            widget == centralWidget() ||
+            qobject_cast<QFrame*>(widget) != nullptr)
+        {
+            continue;
         }
+
+        // A list of widgets that are ALWAYS re-enabled and have their state
+        // re-evaluated by other functions.
+        if (widget == compressButton ||
+            widget == cancelButton)
+        {
+            continue;
+        }
+
+        widget->setEnabled(enabled);
     }
+
+    // Explicitly manage the state of the primary action buttons
     compressButton->setEnabled(enabled);
     cancelButton->setEnabled(!enabled);
+
+    // If we are re-enabling controls, we must restore the dynamic states
+    // based on current settings.
     if (enabled) {
         onEncoderChanged(encoderComboBox->currentIndex());
         onAudioSettingsChanged();


### PR DESCRIPTION
The `setControlsEnabled` function was not correctly disabling all UI controls during the compression process. This was because it was only iterating through the direct children of the central widget, and not recursively through all nested widgets.

This commit fixes the bug by using `findChildren<QWidget *>()` to recursively find all child widgets of the main window and disable them. This ensures that you cannot interact with the UI while the compression is in progress, which could lead to unexpected behavior.